### PR TITLE
feat: 엔티티 추가(order, county, delivery_fee)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.9",
-        "typeorm-extension": "^2.1.10"
+        "typeorm-extension": "^2.1.10",
+        "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -8370,6 +8371,14 @@
         "typeorm": "~0.3.0"
       }
     },
+    "node_modules/typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "peerDependencies": {
+        "typeorm": "^0.2.0 || ^0.3.0"
+      }
+    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -15093,6 +15102,12 @@
         "reflect-metadata": "^0.1.13",
         "yargs": "^17.5.1"
       }
+    },
+    "typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "requires": {}
     },
     "typescript": {
       "version": "4.8.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "typeorm": "^0.3.9",
-    "typeorm-extension": "^2.1.10"
+    "typeorm-extension": "^2.1.10",
+    "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeormService } from './database';
 
 @Module({
-  imports: [],
+  imports: [
+    TypeOrmModule.forRootAsync({
+      useClass: TypeormService,
+    }),
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/countries/entities/country.entity.ts
+++ b/src/countries/entities/country.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { DeliveryFeeEntity as DeliveryFee } from '../../deliveryFee/entities/deliveryFee.entity';
+import { OrderEntity as Order } from '../../orders/entities/order.entity';
+
+@Entity('country')
+export class CountryEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false, unique: true })
+  countryCode: string;
+
+  @Column({ nullable: false })
+  countryDcode: string;
+
+  @Column({ nullable: false, unique: true })
+  countryName: string;
+
+  @OneToMany(() => DeliveryFee, (deliveryFee) => deliveryFee.country, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  deliveryFee: DeliveryFee[];
+
+  @OneToMany(() => Order, (order) => order.country, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  orders: Order[];
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { TypeOrmOptionsFactory, TypeOrmModuleOptions } from '@nestjs/typeorm';
-
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { TYPEORM } from '../config';
 
 @Injectable()
@@ -8,7 +8,9 @@ export class TypeormService implements TypeOrmOptionsFactory {
   async createTypeOrmOptions(): Promise<TypeOrmModuleOptions> {
     return {
       ...TYPEORM,
-      entities: [__dirname + '/../../**/**/*.entity{.ts,.js}'],
+      namingStrategy: new SnakeNamingStrategy(),
+      synchronize: true,
+      entities: [__dirname + '/../**/**/*.entity{.ts,.js}'],
       logging: true,
     };
   }

--- a/src/deliveryFee/entities/deliveryFee.entity.ts
+++ b/src/deliveryFee/entities/deliveryFee.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { CountryEntity as Country } from '../../countries/entities/country.entity';
+
+@Entity('delivery_fee')
+export class DeliveryFeeEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  quantity: number;
+
+  @Column({ nullable: false })
+  fee: number;
+
+  @ManyToOne(() => Country, (country) => country.deliveryFee, {
+    nullable: false,
+  })
+  country: Country;
+}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CountryEntity as Country } from '../../countries/entities/country.entity';
+
+export type OrderStatus =
+  | '결제완료'
+  | '결제취소'
+  | '배송중'
+  | '배송완료'
+  | '구매확정'
+  | '교환'
+  | '환불';
+
+@Entity('order')
+export class OrderEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    type: 'enum',
+    enum: [
+      '결제완료',
+      '결제취소',
+      '배송중',
+      '배송완료',
+      '구매확정',
+      '교환',
+      '환불',
+    ],
+    default: '결제완료',
+  })
+  status: OrderStatus;
+
+  @Column({ nullable: false })
+  quantity: number;
+
+  @Column({ nullable: false })
+  price: number;
+
+  @Column({ nullable: false })
+  buyrCity: string;
+
+  @Column({ nullable: false })
+  buyrCounty: string;
+
+  @Column({ nullable: false })
+  buyrZipx: string;
+
+  @Column({ nullable: false })
+  vscode: string;
+
+  @ManyToOne(() => Country, (country) => country.deliveryFee, {
+    nullable: false,
+  })
+  country: Country;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  startedAt: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    nullable: true,
+    default: () => null,
+  })
+  endedAt: Date;
+}


### PR DESCRIPTION
## feat: 엔티티 추가(order, county, delivery_fee)
- 기본으로 제공되었던 데이터 order, county, delivery_fee의 엔티티 추가
- delivery_fee 테이블은 country의 id를 외래키로 사용하기 위해 테이블 구조를 id(pk), quantity, fee, country_id(fk)로 변경
- 관계 설명
  - 주문 N : 국가 1
  - 국가 1: 배송료 N
  - 차후 생성될 쿠폰 테이블은 쿠폰 1 : 주문 N의 관계를 가짐
- 현재까지 작성한 ERD
![image](https://user-images.githubusercontent.com/30682847/189688001-60c95081-97b9-42a5-aff0-e34965d4b097.png)
