### PR TITLE
feat: coupon entity 생성

### DIFF
--- a/src/coupons/entities/coupon.entity.ts
+++ b/src/coupons/entities/coupon.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { CouponType } from './coupon.type';
+import { OrderEntity as Order } from '../../orders/entities/order.entity';
+
+type CouponType = typeof CouponType[keyof typeof CouponType];
+
+@Entity('coupon')
+export class CouponEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  code: string;
+
+  @Column({ type: 'enum', enum: CouponType, nullable: false })
+  type: CouponType;
+
+  @Column({ nullable: false })
+  amount: number;
+
+  @Column({ nullable: false, default: 0 })
+  use: number;
+
+  @Column({ nullable: false })
+  remains: number;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    nullable: false,
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  createdAt: Date;
+
+  @Column({ type: 'timestamp', nullable: false })
+  expirationDate: Date;
+
+  @OneToMany(() => Order, (order) => order.coupon, {})
+  orders: Order[];
+}

--- a/src/coupons/entities/coupon.type.ts
+++ b/src/coupons/entities/coupon.type.ts
@@ -1,0 +1,5 @@
+export const CouponType = {
+  fixed: 'fixed',
+  rate: 'rate',
+  delivery: 'delivery',
+};

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { CountryEntity as Country } from '../../countries/entities/country.entity';
+import { CouponEntity as Coupon } from '../../coupons/entities/coupon.entity';
 import { OrderStatus } from './order.status';
 
 type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
@@ -41,10 +42,15 @@ export class OrderEntity {
   @Column({ nullable: false })
   vscode: string;
 
-  @ManyToOne(() => Country, (country) => country.deliveryFee, {
+  @ManyToOne(() => Country, (country) => country.orders, {
     nullable: false,
   })
   country: Country;
+
+  @ManyToOne(() => Coupon, (coupon) => coupon.orders, {
+    nullable: true,
+  })
+  coupon: Coupon;
 
   @CreateDateColumn({
     type: 'timestamp',


### PR DESCRIPTION
## feat: coupon entity 생성
- 쿠폰 엔티티의 필드값
  - id
  - type(% / 특정 금액 / 배송비)
  - code,
  - value(각 타입에 맞는 할인률 | 금액 | 배송비 전액 할인)
  - amount
  - use
  - ramains
  - createdAt
  - expirationDate
- 쿠폰 엔티티와 주문 엔티티는 1: N의 관계를 가짐