### PR TITLE
Feature/7

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,13 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeormService } from './database';
+import { OrdersModule } from './orders/orders.module';
+import { DeliveryFeeModule } from './deliveryFee/deliveryFee.module';
 
 @Module({
   imports: [
+    OrdersModule,
+    DeliveryFeeModule,
     TypeOrmModule.forRootAsync({
       useClass: TypeormService,
     }),

--- a/src/deliveryFee/deliveryFee.module.ts
+++ b/src/deliveryFee/deliveryFee.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DeliveryFeeService } from './deliveryFee.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DeliveryFeeEntity } from './entities/deliveryFee.entity';
+import { CountryEntity } from '../countries/entities/country.entity';
+
+@Module({
+  providers: [DeliveryFeeService],
+  imports: [TypeOrmModule.forFeature([DeliveryFeeEntity, CountryEntity])],
+})
+export class DeliveryFeeModule {}

--- a/src/deliveryFee/deliveryFee.service.spec.ts
+++ b/src/deliveryFee/deliveryFee.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeliveryFeeService } from './deliveryFee.service';
+
+describe('DeliveryFeeService', () => {
+  let service: DeliveryFeeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DeliveryFeeService],
+    }).compile();
+
+    service = module.get<DeliveryFeeService>(DeliveryFeeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/deliveryFee/deliveryFee.service.ts
+++ b/src/deliveryFee/deliveryFee.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DeliveryFeeEntity } from './entities/deliveryFee.entity';
+import { Repository } from 'typeorm';
+import { CountryEntity } from '../countries/entities/country.entity';
+
+@Injectable()
+export class DeliveryFeeService {
+  constructor(
+    @InjectRepository(DeliveryFeeEntity)
+    private deliveryRepository: Repository<DeliveryFeeEntity>,
+    @InjectRepository(CountryEntity)
+    private countryRepository: Repository<CountryEntity>
+  ) {}
+
+  async getDeliveryFee(country: CountryEntity, quantity: number) {
+    const delivery = await this.deliveryRepository.findOne({
+      relations: ['country'],
+      where: { country: country, quantity: quantity },
+    });
+
+    if (!delivery) {
+      throw new NotFoundException(
+        'The requested URL was not found on this server.'
+      );
+    }
+
+    return delivery.fee;
+  }
+}

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,36 @@
+import { CountryEntity as Country } from '../../countries/entities/country.entity';
+import { CouponEntity as Coupon } from '../../coupons/entities/coupon.entity';
+import { OrderStatus } from '../entities/order.status';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
+
+export class CreateOrderDto {
+  @IsString()
+  status: OrderStatus;
+
+  @IsNumber()
+  @IsNotEmpty()
+  quantity: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  price: number;
+
+  @IsString()
+  buyrCity: string;
+
+  @IsString()
+  @IsNotEmpty()
+  buyrCounty: string;
+
+  @IsString()
+  buyrZipx: string;
+
+  @IsString()
+  @IsNotEmpty()
+  vscode: string;
+
+  @IsString()
+  coupon: Coupon;
+}

--- a/src/orders/orders.controller.spec.ts
+++ b/src/orders/orders.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersController } from './orders.controller';
+
+describe('OrdersController', () => {
+  let controller: OrdersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrdersController],
+    }).compile();
+
+    controller = module.get<OrdersController>(OrdersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  create(@Body() createOrderDto: CreateOrderDto) {
+    return this.ordersService.create(createOrderDto);
+  }
+}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OrderEntity } from './entities/order.entity';
+import { CountryEntity } from '../countries/entities/country.entity';
+import { DeliveryFeeService } from '../deliveryFee/deliveryFee.service';
+import { DeliveryFeeEntity } from '../deliveryFee/entities/deliveryFee.entity';
+
+@Module({
+  controllers: [OrdersController],
+  providers: [OrdersService, DeliveryFeeService],
+  imports: [
+    TypeOrmModule.forFeature([OrderEntity, CountryEntity, DeliveryFeeEntity]),
+  ],
+})
+export class OrdersModule {}

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersService } from './orders.service';
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OrdersService],
+    }).compile();
+
+    service = module.get<OrdersService>(OrdersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OrderEntity } from './entities/order.entity';
+import { Repository } from 'typeorm';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { DeliveryFeeService } from '../deliveryFee/deliveryFee.service';
+import { CountryEntity } from '../countries/entities/country.entity';
+
+@Injectable()
+export class OrdersService {
+  constructor(
+    @InjectRepository(OrderEntity)
+    private ordersRepository: Repository<OrderEntity>,
+    @InjectRepository(CountryEntity)
+    private countryRepository: Repository<CountryEntity>,
+    @Inject(DeliveryFeeService)
+    private deliveryFeeService: DeliveryFeeService
+  ) {}
+
+  async create(
+    createOrderDto: CreateOrderDto
+  ): Promise<CreateOrderDto | undefined> {
+    const country = await this.countryRepository.findOneBy({
+      countryCode: createOrderDto.buyrCounty,
+    });
+
+    console.log(country.id);
+
+    const deliveryFee = await this.deliveryFeeService.getDeliveryFee(
+      country,
+      createOrderDto.quantity
+    );
+
+    console.log(deliveryFee);
+
+    return createOrderDto;
+  }
+}


### PR DESCRIPTION
## feat: deliveryService 생성
- deliveryService는 getDeliveryFee(country: CountryEntity, quantity: number) 메서드 가지고 있음
- 파라미터인 country 엔티티를 통해 주어진 특정 country 엔티티를 외래키로 가진 데이터만을 찾은 후 quantity 값에 해당하는 행을 가져옴
- 이후 fee 필드 값을 반환

## feat: orders resource 생성
- 해당 프로젝트의 가장 핵심이 되는 orders resource
- 현재, POST: /orders 메서드를 사용할 경우 buyrCounty에 해당하는 country 엔티티를 찾은 후 deliveryFeeService에 quantity와 함께 인자로 전달함으로써, 배송비를 가져올 수 있도록 구현됨
- 리팩토링 및 추가 구현이 매우매우 필요함