### PR TITLE
feat: GET /orders 구현

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -9,9 +9,9 @@ export class TypeormService implements TypeOrmOptionsFactory {
     return {
       ...TYPEORM,
       namingStrategy: new SnakeNamingStrategy(),
-      synchronize: true,
+      // synchronize: true,
       entities: [__dirname + '/../**/**/*.entity{.ts,.js}'],
-      logging: true,
+      // logging: true,
     };
   }
 }

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -22,7 +22,7 @@ export class CreateOrderDto {
 
   @IsString()
   @IsNotEmpty()
-  buyrCounty: string;
+  buyrCountry: string;
 
   @IsString()
   buyrZipx: string;

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -34,7 +34,7 @@ export class OrderEntity {
   buyrCity: string;
 
   @Column({ nullable: false })
-  buyrCounty: string;
+  buyrCountry: string;
 
   @Column({ nullable: false })
   buyrZipx: string;

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,10 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  findAll(@Query() { page }) {
+    return this.ordersService.findAll(page);
+  }
 
   @Post()
   create(@Body() createOrderDto: CreateOrderDto) {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -17,11 +17,25 @@ export class OrdersService {
     private deliveryFeeService: DeliveryFeeService
   ) {}
 
+  async findAll(page = 1) {
+    const take = 20;
+
+    return await this.ordersRepository
+      .createQueryBuilder('order')
+      .select('order.id')
+      .addSelect('order.status')
+      .addSelect('order.price')
+      .addSelect('order.buyrCountry')
+      .take(take)
+      .skip(take * (page - 1))
+      .getMany();
+  }
+
   async create(
     createOrderDto: CreateOrderDto
   ): Promise<CreateOrderDto | undefined> {
     const country = await this.countryRepository.findOneBy({
-      countryCode: createOrderDto.buyrCounty,
+      countryCode: createOrderDto.buyrCountry,
     });
 
     console.log(country.id);


### PR DESCRIPTION
## feat: GET /orders 구현
- OrdersController에서 findAll() 메서드 구현
  - pagination을 적용해 20개씩 로드 {ex) page 1인 경우 1~20개 로드}
```
  @Get()
  findAll(@Query() { page }) {
    return this.ordersService.findAll(page);
  }
```
- OrdersService에서 findAll() 구현
  - 여러개를 보여주기 때문에 id, status, price, buyrCountry 필드값만 노출
```
async findAll(page = 1) {
    const take = 20;

    return await this.ordersRepository
      .createQueryBuilder('order')
      .select('order.id')
      .addSelect('order.status')
      .addSelect('order.price')
      .addSelect('order.buyrCountry')
      .take(take)
      .skip(take * (page - 1))
      .getMany();
  }
```