### PR TITLE
feat: GET /orders/:id 구현

### DIFF
--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 
@@ -9,6 +9,11 @@ export class OrdersController {
   @Get()
   findAll(@Query() { page }) {
     return this.ordersService.findAll(page);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.ordersService.findOne(+id);
   }
 
   @Post()

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { OrderEntity } from './entities/order.entity';
 import { Repository } from 'typeorm';
@@ -29,6 +29,20 @@ export class OrdersService {
       .take(take)
       .skip(take * (page - 1))
       .getMany();
+  }
+
+  async findOne(id: number) {
+    const post = await this.ordersRepository.findOneBy({ id: id });
+
+    if (!post) {
+      throw new NotFoundException();
+    }
+
+    if (!post.endedAt) {
+      delete post.endedAt;
+    }
+
+    return post;
   }
 
   async create(


### PR DESCRIPTION
## feat: GET /orders/:id 구현
- OrdersController에서 findOne() 메서드 구현
```
@Get(':id')
findOne(@Param('id') id: string) {
  return this.ordersService.findOne(+id);
}
```

- OrdersService에서 findOne() 메서드 구현
  -  주문에 대한 상세 정보를 보는 메서드이므로 모든 필드 노출(주문 종료가 되지 않은 경우 ended_at은 표시되지 않음)
  - 찾는 id 값이 없는 경우 NotFoundException 404 코드 반환
```
async findOne(id: number) {
    const post = await this.ordersRepository.findOneBy({ id: id });

    if (!post) {
      throw new NotFoundException();
    }

    if (!post.endedAt) {
      delete post.endedAt;
    }

    return post;
}
```