### PR TITLE
feat: 제품 배송 상태 업데이트(PATCH: /orders/:id) 구현

### DIFF
--- a/src/orders/dto/update-order-status.dto.ts
+++ b/src/orders/dto/update-order-status.dto.ts
@@ -1,0 +1,7 @@
+import { OrderStatus } from '../entities/order.status';
+
+type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
+
+export class UpdateOrderStatusDto {
+  readonly status: OrderStatus;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,10 +1,24 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  create(@Body() createOrderDto: CreateOrderDto) {
+    return this.ordersService.create(createOrderDto);
+  }
 
   @Get()
   findAll(@Query() { page }) {
@@ -16,8 +30,11 @@ export class OrdersController {
     return this.ordersService.findOne(+id);
   }
 
-  @Post()
-  create(@Body() createOrderDto: CreateOrderDto) {
-    return this.ordersService.create(createOrderDto);
+  @Patch(':id')
+  updateOrderStatus(
+    @Param('id') id: string,
+    @Body() updateOrderStatusDto: UpdateOrderStatusDto
+  ) {
+    return this.ordersService.updateOrderStatus(+id, updateOrderStatusDto);
   }
 }


### PR DESCRIPTION
## feat: 제품 배송 상태 업데이트(PATCH: /orders/:id) 구현

- 주문 상태는 결제완료 | 결제취소 | 배송중 | 배송완료 | 구매확정 | 교환 | 환불이 있음

- OrdersController에 updateOrderStatus() 구현
- OrdersService에 updateOrderStatus() 구현
  - 만약, status가 '구매확정'이면 ended_at 값을 입력함.
```
async updateOrderStatus(
    id: number,
    updateOrderStatusDto: UpdateOrderStatusDto
  ) {
    const order = await this.ordersRepository.findOneBy({ id: id });

    if (!order) {
      throw new NotFoundException();
    }

    if (!(updateOrderStatusDto.status in OrderStatus)) {
      throw new BadRequestException();
    }

    if (updateOrderStatusDto.status === OrderStatus.구매확정) {
      order.endedAt = new Date();
    }

    order.status = updateOrderStatusDto.status;

    await this.ordersRepository.save(order);

    return order;
}
```