### PR TITLE
feat: 주문자명으로 검색 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
+        "@faker-js/faker": "^7.5.0",
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.5.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -9,6 +9,7 @@ import {
 import { CountryEntity as Country } from '../../countries/entities/country.entity';
 import { CouponEntity as Coupon } from '../../coupons/entities/coupon.entity';
 import { OrderStatus } from './order.status';
+import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
 
 type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
 
@@ -29,6 +30,9 @@ export class OrderEntity {
 
   @Column({ nullable: false })
   price: number;
+
+  @Column({ nullable: true })
+  buyrName: string;
 
   @Column({ nullable: false })
   buyrCity: string;

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -21,7 +21,11 @@ export class OrdersController {
   }
 
   @Get()
-  findAll(@Query() { page }) {
+  findAll(@Query() { name, page }) {
+    if (!!name) {
+      return this.ordersService.findByName(name, page);
+    }
+
     return this.ordersService.findAll(page);
   }
 

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -12,6 +12,7 @@ import { DeliveryFeeService } from '../deliveryFee/deliveryFee.service';
 import { CountryEntity } from '../countries/entities/country.entity';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { OrderStatus } from './entities/order.status';
+import { faker } from '@faker-js/faker';
 
 @Injectable()
 export class OrdersService {
@@ -51,6 +52,7 @@ export class OrdersService {
       .select('order.id')
       .addSelect('order.status')
       .addSelect('order.price')
+      .addSelect('order.buyrName')
       .addSelect('order.buyrCountry')
       .take(take)
       .skip(take * (page - 1))
@@ -69,6 +71,18 @@ export class OrdersService {
     }
 
     return post;
+  }
+
+  async findByName(name: string, page = 1) {
+    const take = 20;
+
+    return await this.ordersRepository
+      .createQueryBuilder('order')
+      .where('order.buyrName like :name', { name: `%${name}%` })
+      .take(20)
+      .take(take)
+      .skip(take * (page - 1))
+      .getMany();
   }
 
   async updateOrderStatus(


### PR DESCRIPTION
## feat: 주문자명으로 검색 기능 추가
- 현재 orders에는 주문자명 필드가 없으므로 주문자명 필드 생성 
- 주문자명 기준 search 메서드를 order service에 생성
```
 async findByName(name: string, page = 1) {
    const take = 20;

    return await this.ordersRepository
      .createQueryBuilder('order')
      .where('order.buyrName like :name', { name: `%${name}%` })
      .take(20)
      .take(take)
      .skip(take * (page - 1))
      .getMany();
 }
```
- 쿼리 파라미터에 name 값이 존재한다면, order Service의 findByName 메서드 호출, 리턴