### PR TITLE
Feature/19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
-        "@faker-js/faker": "^7.5.0",
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^7.5.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,14 +5,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeormService } from './database';
 import { OrdersModule } from './orders/orders.module';
 import { DeliveryFeeModule } from './deliveryFee/deliveryFee.module';
-import { CouponsController } from './coupons/coupons.controller';
 import { CouponsModule } from './coupons/coupons.module';
+import { CurrencyModule } from './currency/currency.module';
 
 @Module({
   imports: [
     OrdersModule,
     DeliveryFeeModule,
     CouponsModule,
+    CurrencyModule,
     TypeOrmModule.forRootAsync({
       useClass: TypeormService,
     }),

--- a/src/common/interceptors/transform.interceptor.ts
+++ b/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,18 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { map, Observable } from 'rxjs';
+import { instanceToPlain } from 'class-transformer';
+
+@Injectable()
+export class TransformInterceptor implements NestInterceptor {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(map((data) => instanceToPlain(data)));
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -45,9 +45,15 @@ const TYPEORM = environment[NODE_ENV];
 const TYPEORM_SEEDING_SEEDS = env.TYPEORM_SEEDING_SEEDS;
 const TYPEORM_SEEDING_FACTORIES = env.TYPEORM_SEEDING_FACTORIES;
 
+// Exchange Rate API
+const EXCHANGE_API_KEY = env.EXCHANGE_API_KEY;
+const EXCHANGE_DATA = 'AP01';
+const EXCHANGE_URL = `https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=${EXCHANGE_API_KEY}&data=${EXCHANGE_DATA}`;
+
 export {
   TYPEORM,
   BCRYPT_SALT,
   TYPEORM_SEEDING_SEEDS,
   TYPEORM_SEEDING_FACTORIES,
+  EXCHANGE_URL,
 };

--- a/src/coupons/coupons.service.ts
+++ b/src/coupons/coupons.service.ts
@@ -5,11 +5,11 @@ import {
 } from '@nestjs/common';
 import { CreateCouponDto } from './dto/create-coupon.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { CouponEntity as Coupon } from './entities/coupon.entity';
+import { CouponEntity, CouponEntity as Coupon } from './entities/coupon.entity';
 import { Repository } from 'typeorm';
 import { CouponType } from './entities/coupon.type';
 import { UpdateCouponDto } from './dto/update-coupon.dto';
-import { firstValueFrom } from 'rxjs';
+import { CreateOrderDto } from '../orders/dto/create-order.dto';
 
 @Injectable()
 export class CouponsService {
@@ -61,6 +61,45 @@ export class CouponsService {
     return coupon;
   }
 
+  async findOneByCode(couponCode: string) {
+    const coupon = await this.couponRepository.findOneBy({
+      code: couponCode,
+    });
+
+    if (!coupon) {
+      throw new NotFoundException();
+    }
+
+    return coupon;
+  }
+
+  async getDiscountPrice(
+    coupon: CouponEntity,
+    order: CreateOrderDto
+  ): Promise<number | undefined> {
+    if (coupon.international && order.buyrCountry === 'KR') {
+      throw new BadRequestException(
+        `International coupon not valid for ${order.buyrCountry}`
+      );
+    } else if (!coupon.international && order.buyrCountry !== 'KR') {
+      throw new BadRequestException(
+        `National coupon not valid for ${order.buyrCountry}`
+      );
+    }
+
+    if (coupon.type === CouponType.delivery) {
+      return order.deliveryFee;
+    } else if (coupon.type === CouponType.fixed) {
+      return order.price <= coupon.value ? order.price : coupon.value;
+    }
+
+    const rateDiscountPrice =
+      Math.round((order.price * (coupon.value / 100) + Number.EPSILON) * 100) /
+      100;
+
+    return rateDiscountPrice >= order.price ? order.price : rateDiscountPrice;
+  }
+
   async update(
     id: number,
     updateCouponDto: UpdateCouponDto
@@ -81,6 +120,19 @@ export class CouponsService {
     await this.couponRepository.save(coupon);
 
     return coupon;
+  }
+
+  async updateCouponQuantities(coupon: Coupon): Promise<boolean | undefined> {
+    const couponEntity = await this.couponRepository.findOne({
+      relations: ['orders'],
+      select: ['orders'],
+      where: { id: coupon.id },
+    });
+
+    couponEntity.use = couponEntity.orders.length;
+    couponEntity.remains = couponEntity.amount - couponEntity.use;
+
+    return (await this.couponRepository.save(couponEntity)) && true;
   }
 
   async delete(id: number): Promise<boolean | undefined> {

--- a/src/coupons/dto/create-coupon.dto.ts
+++ b/src/coupons/dto/create-coupon.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsDate,
   IsEnum,
   IsNotEmpty,
@@ -15,21 +16,23 @@ export class CreateCouponDto {
   code: string;
 
   @IsEnum(CouponType)
-  @IsNotEmpty()
   type: CouponType;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  international: boolean;
 
   @IsNotEmpty()
   value: number;
 
+  totalDiscountAmount?: number = 0;
+
   @IsNotEmpty()
   amount: number;
 
-  @IsNumber()
-  use: number;
+  use?: number = 0;
 
-  @IsNumber()
   remains: number;
 
-  @IsDate()
   expirationDate: Date;
 }

--- a/src/coupons/entities/coupon.entity.ts
+++ b/src/coupons/entities/coupon.entity.ts
@@ -15,11 +15,14 @@ export class CouponEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, unique: true })
   code: string;
 
   @Column({ type: 'enum', enum: CouponType, nullable: false })
   type: CouponType;
+
+  @Column({ type: 'boolean', nullable: false })
+  international: boolean;
 
   @Column({ nullable: false })
   value: number;
@@ -32,6 +35,9 @@ export class CouponEntity {
 
   @Column({ nullable: false })
   remains: number;
+
+  @Column({ nullable: false, default: 0 })
+  totalDiscountAmount: number;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/currency/currency.module.ts
+++ b/src/currency/currency.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CurrencyService } from './currency.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CurrencyEntity } from './entities/currency.entity';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+  providers: [CurrencyService],
+  imports: [TypeOrmModule.forFeature([CurrencyEntity]), HttpModule],
+})
+export class CurrencyModule {}

--- a/src/currency/currency.service.ts
+++ b/src/currency/currency.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HttpService } from '@nestjs/axios';
+import { EXCHANGE_URL } from '../config';
+import { firstValueFrom } from 'rxjs';
+import { CreateCurrencyInfoDto } from './dto/create-currency-info.dto';
+import { CurrencyEntity } from './entities/currency.entity';
+
+@Injectable()
+export class CurrencyService {
+  constructor(
+    @InjectRepository(CurrencyEntity)
+    private currencyRepository: Repository<CurrencyEntity>,
+    private readonly httpService: HttpService
+  ) {}
+
+  async exchangeToDollar(won: number): Promise<number | undefined> {
+    const currency = await this.getTodayCurrency();
+
+    const wonPerDollar = currency.won;
+
+    // 소수점 이하 두 자리까지 반올림 후 반환
+    return Math.round((won / wonPerDollar + Number.EPSILON) * 100) / 100;
+  }
+
+  async exchangeToWon(dollar: number): Promise<number | undefined> {
+    const currency = await this.getTodayCurrency();
+
+    const wonPerDollar = currency.won;
+
+    // 소수점 이하 두 자리까지 반올림 후 반환
+    return Math.round((dollar * wonPerDollar + Number.EPSILON) * 100) / 100;
+  }
+
+  /**
+   * @description
+   * - API 호출이 일 1,000회이기 때문에 같은 날짜의 환율 데이터가 있는 경우 재활용
+   * @returns {Promise<CurrencyEntity | undefined>}
+   * @private
+   */
+  private async getTodayCurrency(): Promise<CurrencyEntity | undefined> {
+    const currency = await this.currencyRepository.findOneBy({
+      date: this.getToday(),
+    });
+
+    return currency || (await this.appendAndGetCurrencyData());
+  }
+
+  private async appendAndGetCurrencyData(): Promise<CurrencyEntity> {
+    const today = this.getToday();
+
+    const { data } = await firstValueFrom(this.httpService.get(EXCHANGE_URL));
+
+    console.log(data);
+
+    let wonPerDollar;
+
+    /**
+     * @description
+     * - 비영업일의 데이터, 영업당일 11시 이전에 해당일의 데이터를 요청할 경우 null 값이 반환
+     * - null 값이 반환되는 경우 전날 환율 적용
+     */
+    try {
+      wonPerDollar = data.filter(function (e) {
+        return e.cur_unit === 'USD';
+      })[0].bkpr;
+
+      wonPerDollar = wonPerDollar.replace(',', '');
+    } catch (e) {
+      const latestCurrency = await this.currencyRepository.find({
+        order: { date: 'DESC' },
+        take: 1,
+      });
+
+      wonPerDollar = latestCurrency[0].won;
+    }
+
+    return await this.currencyRepository.save(
+      new CreateCurrencyInfoDto(1, wonPerDollar, today)
+    );
+  }
+
+  private getToday(): string {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = ('0' + (1 + date.getMonth())).slice(-2);
+    const day = ('0' + date.getDate()).slice(-2);
+
+    return year + '-' + month + '-' + day;
+  }
+}

--- a/src/currency/currency.service.ts
+++ b/src/currency/currency.service.ts
@@ -52,8 +52,6 @@ export class CurrencyService {
 
     const { data } = await firstValueFrom(this.httpService.get(EXCHANGE_URL));
 
-    console.log(data);
-
     let wonPerDollar;
 
     /**

--- a/src/currency/dto/create-currency-info.dto.ts
+++ b/src/currency/dto/create-currency-info.dto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class CreateCurrencyInfoDto {
+  constructor(dollar: number, won: number, date: string) {
+    this.dollar = dollar;
+    this.won = won;
+    this.date = date;
+  }
+
+  @IsNotEmpty()
+  dollar: number;
+
+  @IsNotEmpty()
+  won: number;
+
+  @IsNotEmpty()
+  date: string;
+}

--- a/src/currency/entities/currency.entity.ts
+++ b/src/currency/entities/currency.entity.ts
@@ -1,5 +1,4 @@
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { LocalDate } from '@js-joda/core';
 
 @Entity('currency')
 export class CurrencyEntity {

--- a/src/currency/entities/currency.entity.ts
+++ b/src/currency/entities/currency.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { LocalDate } from '@js-joda/core';
+
+@Entity('currency')
+export class CurrencyEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  dollar: number;
+
+  @Column({ nullable: false })
+  won: number;
+
+  @Column({ type: 'date' })
+  date: string;
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -9,7 +9,7 @@ export class TypeormService implements TypeOrmOptionsFactory {
     return {
       ...TYPEORM,
       namingStrategy: new SnakeNamingStrategy(),
-      // synchronize: true,
+      synchronize: true,
       entities: [__dirname + '/../**/**/*.entity{.ts,.js}'],
       // logging: true,
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    })
+  );
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -2,35 +2,51 @@ import { CountryEntity as Country } from '../../countries/entities/country.entit
 import { CouponEntity as Coupon } from '../../coupons/entities/coupon.entity';
 import { OrderStatus } from '../entities/order.status';
 import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { Exclude } from 'class-transformer';
 
 type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
 
 export class CreateOrderDto {
-  @IsString()
-  status: OrderStatus;
+  readonly status: OrderStatus;
 
   @IsNumber()
   @IsNotEmpty()
-  quantity: number;
+  readonly quantity: number;
 
   @IsNumber()
   @IsNotEmpty()
-  price: number;
+  readonly price: number;
 
-  @IsString()
-  buyrCity: string;
+  deliveryFee: number;
 
-  @IsString()
-  @IsNotEmpty()
-  buyrCountry: string;
+  discountPrice?: number = 0;
 
-  @IsString()
-  buyrZipx: string;
+  total: number;
 
   @IsString()
   @IsNotEmpty()
-  vscode: string;
+  readonly buyrName: string;
 
   @IsString()
+  readonly buyrCity: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly buyrCountry: string;
+
+  @IsString()
+  readonly buyrZipx: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly vscode: string;
+
+  @IsString()
+  couponCode: string;
+
+  @Exclude()
+  country: Country;
+
+  @Exclude()
   coupon: Coupon;
 }

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -9,7 +9,6 @@ import {
 import { CountryEntity as Country } from '../../countries/entities/country.entity';
 import { CouponEntity as Coupon } from '../../coupons/entities/coupon.entity';
 import { OrderStatus } from './order.status';
-import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
 
 type OrderStatus = typeof OrderStatus[keyof typeof OrderStatus];
 
@@ -31,16 +30,25 @@ export class OrderEntity {
   @Column({ nullable: false })
   price: number;
 
-  @Column({ nullable: true })
-  buyrName: string;
+  @Column({ nullable: false })
+  deliveryFee: number;
+
+  @Column({ default: 0, nullable: false })
+  discountPrice: number;
 
   @Column({ nullable: false })
+  total: number;
+
+  @Column({ nullable: false })
+  buyrName: string;
+
+  @Column({ nullable: true })
   buyrCity: string;
 
   @Column({ nullable: false })
   buyrCountry: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   buyrZipx: string;
 
   @Column({ nullable: false })

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -6,16 +6,19 @@ import {
   Patch,
   Post,
   Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+import { TransformInterceptor } from '../common/interceptors/transform.interceptor';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
+  @UseInterceptors(new TransformInterceptor())
   create(@Body() createOrderDto: CreateOrderDto) {
     return this.ordersService.create(createOrderDto);
   }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule } from '@nestjs/common';
 import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -6,12 +6,29 @@ import { OrderEntity } from './entities/order.entity';
 import { CountryEntity } from '../countries/entities/country.entity';
 import { DeliveryFeeService } from '../deliveryFee/deliveryFee.service';
 import { DeliveryFeeEntity } from '../deliveryFee/entities/deliveryFee.entity';
+import { CurrencyService } from '../currency/currency.service';
+import { CurrencyEntity } from '../currency/entities/currency.entity';
+import { HttpModule, HttpService } from '@nestjs/axios';
+import { CouponsService } from '../coupons/coupons.service';
+import { CouponEntity } from '../coupons/entities/coupon.entity';
 
 @Module({
   controllers: [OrdersController],
-  providers: [OrdersService, DeliveryFeeService],
+  providers: [
+    OrdersService,
+    DeliveryFeeService,
+    CurrencyService,
+    CouponsService,
+  ],
   imports: [
-    TypeOrmModule.forFeature([OrderEntity, CountryEntity, DeliveryFeeEntity]),
+    TypeOrmModule.forFeature([
+      OrderEntity,
+      CountryEntity,
+      DeliveryFeeEntity,
+      CurrencyEntity,
+      CouponEntity,
+    ]),
+    HttpModule,
   ],
 })
 export class OrdersModule {}


### PR DESCRIPTION
## feat: 환율 관련 기능 추가
- deliveryFeeService.getDeliveryFee()를 이용해 배송비를 원화로 가져온 뒤, 주문내역의 deliveryFee에는 국내가 아닌 경우 달러로 표시해야 한다.
- 환율 api는 '한국수출입은행 환율 정보' 이용
- API 호출이 일 1,000회이기 때문에 같은 날짜의 환율 데이터가 DB에 있는 경우 재활용
- 비영업일의 데이터, 영업당일 11시 이전에 해당일의 데이터를 요청할 경우 null 값이 반환
- null 값이 반환되는 경우 전날 환율 적용

## feat: 주문내역 추가 기능 구현
- 쿠폰 타입 별 사용 횟수, 총 할인액 조회 가능
- 쿠폰 시스템에 맞게 데이터베이스를 업데이트
- coupon의 적용 국가를 international:boolean으로 설정해 할인이 통화에 맞게 적용되도록 설정